### PR TITLE
Allow excluding of JDK signature checking in Jakarta EE Platform TCK testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ then try:
 
 with the action option set to `strictcheck` the plugin will detect any API change and fail even if it is compatible. 
 
+## Relax verification of JDK signatures
+
+There are some cases where avoiding the verification of certain JDK classes entirely or their signatures can improve the ability to verify your API on different JDK versions.
+The `-IgnoreJDKClass` option can be used to specify a set of JDK classes that can benefit from relaxed signature verification rules when it comes to dealing with JDK 
+specific signature changes introduced by a later JDK version. As an example, a Signature file with @java.lang.Deprecated annotations from JDK8 may be seeing verification failures on JDK9+ 
+due to `default` fields being added to @Deprecated.  With `-IgnoreJDKClass java.lang.Deprecated` enabled, verification of the @Deprecated will only check that the tested class member has the 
+@Deprecated class but no verification of the @Deprecated signature will be performed. 
+
 ## History
 
 This tool is based on original [SigTest](https://wiki.openjdk.java.net/display/CodeTools/sigtest) sources,

--- a/src/main/java/com/sun/tdk/signaturetest/core/JDKExclude.java
+++ b/src/main/java/com/sun/tdk/signaturetest/core/JDKExclude.java
@@ -1,0 +1,44 @@
+/*
+ * $Id:$
+ *
+ * Copyright 2021 Sun Microsystems, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Sun designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Sun in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+ * CA 95054 USA or visit www.sun.com if you need additional information or
+ * have any questions.
+ */
+
+package com.sun.tdk.signaturetest.core;
+
+/**
+ * JDKExclude represents the JDK classes to be excluded from signature testing.
+ *
+ * @author Scott Marlow
+ */
+public interface JDKExclude {
+
+    /**
+     * Check for JDK classes that should be excluded from signature testing.
+     * @param name is class name (with typical dot separators) to check.
+     * @return true if the class should be excluded from signature testing.
+     */
+    boolean isJdkClass(String name);
+   
+}

--- a/src/main/java/com/sun/tdk/signaturetest/core/MemberCollectionBuilder.java
+++ b/src/main/java/com/sun/tdk/signaturetest/core/MemberCollectionBuilder.java
@@ -76,6 +76,16 @@ public class MemberCollectionBuilder {
      */
     static Logger logger = Logger.getLogger(MemberCollectionBuilder.class.getName());
 
+    public MemberCollectionBuilder(Log log, JDKExclude jdkExclude) {
+        this.cc = jdkExclude == null ? new ClassCorrector(log) : new ClassCorrector(log, jdkExclude);
+        this.log = log;
+
+        // not configured externally
+        if (logger.getLevel() == null) {
+            logger.setLevel(Level.OFF);
+        }
+    }
+    
     public MemberCollectionBuilder(Log log) {
         this.cc = new ClassCorrector(log);
         this.log = log;

--- a/src/main/java/com/sun/tdk/signaturetest/core/ThrowsNormalizer.java
+++ b/src/main/java/com/sun/tdk/signaturetest/core/ThrowsNormalizer.java
@@ -43,6 +43,12 @@ import java.util.List;
  */
 public class ThrowsNormalizer {
 
+    public ThrowsNormalizer() {
+        
+    }
+    public ThrowsNormalizer(JDKExclude jdkExclude) {
+        this.jdkExclude = jdkExclude;
+    }
     public void normThrows(ClassDescription c, boolean removeJLE) throws ClassNotFoundException {
 
         ClassHierarchy h = c.getClassHierarchy();
@@ -93,7 +99,8 @@ public class ThrowsNormalizer {
                 if (s == null)
                     continue;
 
-                if (s.charAt(0) != '{' /* if not generic */) {
+
+                if (!jdkExclude.isJdkClass(s) && s.charAt(0) != '{' /* if not generic */) {
 
                     if (checkException(h, s, "java.lang.RuntimeException") || (removeJLE && checkException(h, s, "java.lang.Error"))) {
                         xthrows.set(i, null);
@@ -145,4 +152,10 @@ public class ThrowsNormalizer {
     
     private List/*String*/ xthrows = new ArrayList();
     private StringBuffer sb = new StringBuffer();
+    private JDKExclude jdkExclude = new JDKExclude() {
+        @Override
+        public boolean isJdkClass(String name) {
+            return false;
+        }
+    };
 }

--- a/src/main/resources/com/sun/tdk/signaturetest/i18n.properties
+++ b/src/main/resources/com/sun/tdk/signaturetest/i18n.properties
@@ -188,6 +188,7 @@ SignatureTest.usage.files={0} <filelist> Specify list of signature files. Use {1
 SignatureTest.usage.package={0} <name>   Specify package to be tested along with subpackages
 SignatureTest.usage.packagewithoutsubpackages={0} <name> Specify package to be tested excluding subpackages
 SignatureTest.usage.exclude={0} <name>   Specify package or class, which is not required to be tested
+SignatureTest.usage.excludejdkclass={0} <name>   Specify JDK package or class, which is not required to be tested
 SignatureTest.usage.classpath={0} <path> Specify search path for tested classes in static mode
 SignatureTest.usage.out={0} <file>       Specify report file name
 SignatureTest.usage.static={0}           Run SignatureTest in static mode (default: reflection)


### PR DESCRIPTION
First pass of addressing https://github.com/eclipse-ee4j/jakartaee-tck/issues/156, especially this part mentioned in the description:

> There are some features in the sigtest tool that seem like they should work to limit the recorded signatures to only the API being tested, or to exclude the signatures for JDK classes, but these features have never worked the way I wanted them to work.


I am testing changes on https://github.com/scottmarlow/jakartaee-tck/tree/sigtest_netbeans-script-part2 to pass the Jakarta EE Platform TCK signature tests on JDK11 + JDK16 (with WildFly).  One of the changes that I made in the `sigtest_netbeans-script-part2 ` branch is to remove the JDK11 signature map files and only use the JDK8 signature map files for JDK11+ testing.

https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck-scottmarlow/job/sigtest_netbeans-script-part2/2 is building now and will test my local build of `netbeans-apitest` with the JDK11 version of GlassFish.

I am going to experiment more to see if I can eliminate the ClassCorrector + ThrowsNormalizer changes.  I would prefer to limit changes to SignatureTest and would like to pass the list of JDK packages/classes to exclude as parameters.

I'm almost out of time to make these changes for Jakarta EE 9.1 (would like to finish by end of this week) but am seeing what can be accomplished.

Suggestions or alternatives are welcome.  