### PR TITLE
Use ct.sym to isolate sigtest from underlaying JDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ e.g. the signature file. Just add following into your own `pom.xml` file:
 <plugin>
   <groupId>org.netbeans.tools</groupId>
   <artifactId>sigtest-maven-plugin</artifactId>
-  <version>1.3</version>
+  <version>1.4</version>
   <executions>
     <execution>
       <goals>
@@ -57,7 +57,7 @@ Try the following:
 <plugin>
   <groupId>org.netbeans.tools</groupId>
   <artifactId>sigtest-maven-plugin</artifactId>
-  <version>1.3</version>
+  <version>1.4</version>
   <executions>
     <execution>
       <goals>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ e.g. the signature file. Just add following into your own `pom.xml` file:
     </execution>
   </executions>
   <configuration>
+    <release>8</release> <!-- specify version of JDK API to use 6,7,8,...15 -->
     <packages>org.yourcompany.app.api,org.yourcompany.help.api</packages>
   </configuration>
 </plugin>
@@ -67,6 +68,7 @@ Try the following:
   <configuration>
     <packages>org.yourcompany.app.api,org.yourcompany.help.api</packages>
     <releaseVersion>1.3</releaseVersion>
+    <release>8</release> <!-- specify version of JDK API to use 6,7,8,...15 -->
   </configuration>
 </plugin>
 ```
@@ -129,6 +131,7 @@ then try:
  
     <packages>org.yourcompany.app.api,org.yourcompany.help.api</packages>
     <releaseVersion>1.3</releaseVersion>
+    <release>8</release> <!-- specify version of JDK API to use 6,7,8,...15 -->
   </configuration>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,35 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.frgaal</groupId>
+                                    <artifactId>compiler</artifactId>
+                                    <version>15.0.0</version>
+                                    <type>jar</type>
+                                    <overWrite>false</overWrite>
+                                </artifactItem>
+                            </artifactItems>
+                            <includes>META-INF/ct.sym/**/*</includes>
+                            <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.10</version>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     </scm>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <ct.sym>${java.home}/lib/ct.sym</ct.sym>
     </properties>
     <build>
         <plugins>
@@ -52,20 +53,13 @@
                         <id>unpack</id>
                         <phase>process-resources</phase>
                         <goals>
-                            <goal>unpack</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.frgaal</groupId>
-                                    <artifactId>compiler</artifactId>
-                                    <version>15.0.0</version>
-                                    <type>jar</type>
-                                    <overWrite>false</overWrite>
-                                </artifactItem>
-                            </artifactItems>
-                            <includes>META-INF/ct.sym/**/*</includes>
-                            <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                            <includeGroupIds>org.netbeans.tools</includeGroupIds>
+                            <includes>**/*</includes>
+                            <exclude>META-INF/**</exclude>
+                            <outputDirectory>${project.build.directory}/classes/META-INF/sigtest/</outputDirectory>
                             <overWriteReleases>false</overWriteReleases>
                             <overWriteSnapshots>true</overWriteSnapshots>
                         </configuration>
@@ -85,7 +79,7 @@
                 <version>1.6.0</version>
                 <executions>
                     <execution>
-                        <id>list-ct.sym</id>
+                        <id>list-sigtest</id>
                         <phase>process-classes</phase>
                         <goals>
                             <goal>java</goal>
@@ -93,8 +87,8 @@
                         <configuration>
                             <mainClass>org.netbeans.apitest.ListCtSym</mainClass>
                             <arguments>
-                                <argument>${project.build.directory}/classes/META-INF/ct.sym.ls</argument>
-                                <argument>${project.build.directory}/classes/META-INF/ct.sym/</argument>
+                                <argument>${project.build.directory}/classes/META-INF/sigtest.ls</argument>
+                                <argument>${project.build.directory}/classes/META-INF/sigtest/</argument>
                                 <argument>2</argument>
                             </arguments>
                         </configuration>
@@ -210,6 +204,14 @@
             <artifactId>compiler</artifactId>
             <version>15.0.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.tools</groupId>
+            <artifactId>ct-sym</artifactId>
+            <version>latest</version>
+            <scope>system</scope>
+            <systemPath>${ct.sym}</systemPath>
+            <type>jar</type>
         </dependency>
     </dependencies>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,28 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.6.0</version>
+                <executions>
+                    <execution>
+                        <id>list-ct.sym</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>org.netbeans.apitest.ListCtSym</mainClass>
+                            <arguments>
+                                <argument>${project.build.directory}/classes/META-INF/ct.sym.ls</argument>
+                                <argument>${project.build.directory}/classes/META-INF/ct.sym/</argument>
+                                <argument>2</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
@@ -90,7 +112,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.6.0</version>
                 <configuration>
                     <extractors>
                         <extractor>java-annotations</extractor>

--- a/pom.xml
+++ b/pom.xml
@@ -106,8 +106,9 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
+                    <subpackages>org.netbeans.apitest</subpackages>
                 </configuration>
-                <version>2.10.3</version>
+                <version>3.2.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/sun/tdk/apicover/Main.java
+++ b/src/main/java/com/sun/tdk/apicover/Main.java
@@ -41,6 +41,7 @@ import com.sun.tdk.signaturetest.util.CommandLineParserException;
 import com.sun.tdk.signaturetest.util.I18NResourceBundle;
 import com.sun.tdk.signaturetest.util.OptionInfo;
 import com.sun.tdk.apicover.markup.Adapter;
+import com.sun.tdk.signaturetest.classpath.Release;
 
 import com.sun.tdk.signaturetest.core.MemberCollectionBuilder.BuildMode;
 import com.sun.tdk.signaturetest.sigfile.FileManager;
@@ -247,7 +248,7 @@ public class Main implements Log {
         }
         else if (optionName.equalsIgnoreCase(TS_OPTION)) {
             try {
-                classpath = new ClasspathImpl(true, args[0]);
+                classpath = new ClasspathImpl(Release.BOOT_CLASS_PATH, args[0]);
             } catch (SecurityException e) {
                 debug(e);
                 log.println(i18n.getString("Main.error.sec.newclasses"));

--- a/src/main/java/com/sun/tdk/signaturetest/Setup.java
+++ b/src/main/java/com/sun/tdk/signaturetest/Setup.java
@@ -192,7 +192,7 @@ public class Setup extends SigTest {
 
         parser.addOption(PACKAGE_OPTION, OptionInfo.optionVariableParams(1, OptionInfo.UNLIMITED), optionsDecoder);
         parser.addOption(CLASSPATH_OPTION, OptionInfo.requiredOption(1), optionsDecoder);
-        parser.addOption(USE_BOOT_CP, OptionInfo.optionalFlag(), optionsDecoder);
+        parser.addOption(USE_BOOT_CP, OptionInfo.optionVariableParams(0, 1), optionsDecoder);
         parser.addOption(FILENAME_OPTION, OptionInfo.requiredOption(1), optionsDecoder);
 
         parser.addOption(TESTURL_OPTION, OptionInfo.option(1), optionsDecoder);

--- a/src/main/java/com/sun/tdk/signaturetest/Setup.java
+++ b/src/main/java/com/sun/tdk/signaturetest/Setup.java
@@ -373,7 +373,7 @@ public class Setup extends SigTest {
         getLog().println(i18n.getString("Setup.log.classpath", classpathStr));
 
         try {
-            classpath = new ClasspathImpl(useBootCp, classpathStr);
+            classpath = new ClasspathImpl(release, classpathStr);
         } catch (SecurityException e) {
             if (SigTest.debug)
                 e.printStackTrace();

--- a/src/main/java/com/sun/tdk/signaturetest/SigTest.java
+++ b/src/main/java/com/sun/tdk/signaturetest/SigTest.java
@@ -285,7 +285,15 @@ public abstract class SigTest extends Result implements PluginAPI, Log {
         } else if (optionName.equalsIgnoreCase(CLASSPATH_OPTION)) {
             classpathStr = args[0];
         } else if (optionName.equalsIgnoreCase(USE_BOOT_CP)) {
-            release = Release.BOOT_CLASS_PATH;
+            if (args.length == 0) {
+                release = Release.BOOT_CLASS_PATH;
+            } else {
+                try {
+                    release = Release.find(Integer.parseInt(args[0]));
+                } catch (NumberFormatException ex) {
+                    throw new CommandLineParserException(i18n.getString("SigTest.error.arg.invalid2", optionName, args[0]));
+                }
+            }
         } else if (optionName.equalsIgnoreCase(APIVERSION_OPTION)) {
             apiVersion = args[0];
         } else if (optionName.equalsIgnoreCase(STATIC_OPTION)) {

--- a/src/main/java/com/sun/tdk/signaturetest/SigTest.java
+++ b/src/main/java/com/sun/tdk/signaturetest/SigTest.java
@@ -29,6 +29,7 @@ package com.sun.tdk.signaturetest;
 
 import com.sun.tdk.signaturetest.classpath.Classpath;
 import com.sun.tdk.signaturetest.classpath.ClasspathImpl;
+import com.sun.tdk.signaturetest.classpath.Release;
 import com.sun.tdk.signaturetest.core.*;
 import com.sun.tdk.signaturetest.errors.ErrorFormatter;
 import com.sun.tdk.signaturetest.model.AnnotationItem;
@@ -142,7 +143,7 @@ public abstract class SigTest extends Result implements PluginAPI, Log {
     protected String classpathStr = null;
 
     /** search also boot classpath when a class is not found on classpath? */
-    protected boolean useBootCp;
+    protected Release release;
 
     /**
      * Collector for error messages, or <code>null</code> if log is not required.
@@ -284,7 +285,7 @@ public abstract class SigTest extends Result implements PluginAPI, Log {
         } else if (optionName.equalsIgnoreCase(CLASSPATH_OPTION)) {
             classpathStr = args[0];
         } else if (optionName.equalsIgnoreCase(USE_BOOT_CP)) {
-            useBootCp = true;
+            release = Release.BOOT_CLASS_PATH;
         } else if (optionName.equalsIgnoreCase(APIVERSION_OPTION)) {
             apiVersion = args[0];
         } else if (optionName.equalsIgnoreCase(STATIC_OPTION)) {

--- a/src/main/java/com/sun/tdk/signaturetest/SignatureTest.java
+++ b/src/main/java/com/sun/tdk/signaturetest/SignatureTest.java
@@ -344,7 +344,7 @@ public class SignatureTest extends SigTest {
 
         // required only in static mode!
         parser.addOption(CLASSPATH_OPTION, OptionInfo.option(1), optionsDecoder);
-        parser.addOption(USE_BOOT_CP, OptionInfo.optionalFlag(), optionsDecoder);
+        parser.addOption(USE_BOOT_CP, OptionInfo.optionVariableParams(0, 1), optionsDecoder);
 
         parser.addOption(FILENAME_OPTION, OptionInfo.option(1), optionsDecoder);
         parser.addOption(FILES_OPTION, OptionInfo.option(1), optionsDecoder);

--- a/src/main/java/com/sun/tdk/signaturetest/SignatureTest.java
+++ b/src/main/java/com/sun/tdk/signaturetest/SignatureTest.java
@@ -434,14 +434,14 @@ public class SignatureTest extends SigTest {
 
         // create ClasspathImpl for founding of the added classes
         try {
-            classpath = new ClasspathImpl(useBootCp, classpathStr);
+            classpath = new ClasspathImpl(release, classpathStr);
         } catch (SecurityException e) {
             if (SigTest.debug)
                 e.printStackTrace();
             getLog().println(i18n.getString("SignatureTest.error.sec.newclasses"));
         }
 
-        if (isStatic && classpath.isEmpty() && !useBootCp)
+        if (isStatic && classpath.isEmpty() && release == null)
             return error(i18n.getString("SignatureTest.error.classpath.unspec"));
 
         return passed();

--- a/src/main/java/com/sun/tdk/signaturetest/classpath/ClasspathImpl.java
+++ b/src/main/java/com/sun/tdk/signaturetest/classpath/ClasspathImpl.java
@@ -38,6 +38,7 @@ import java.io.PrintWriter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
 import java.util.*;
 
 /**
@@ -62,7 +63,7 @@ import java.util.*;
  * @see com.sun.tdk.signaturetest.classpath.ClasspathEntry
  */
 public class ClasspathImpl implements Classpath {
-    private final boolean useBootCP;
+    private final Release release;
 
     /*
     public class ClassIterator {
@@ -169,7 +170,7 @@ public class ClasspathImpl implements Classpath {
      * directories and zip files become available through the created
      * <b>ClasspathImpl</b> instance.
      *
-     * @param useBootCP search JDK's bootclasspath when class isn't found?
+     * @param release specify how to search JDK's API when class isn't found on class path
      * @param classPath Path string listing directories and/or zip files.
      * @throws SecurityException The <code>classPath</code> string has
      *                           invalid format.
@@ -178,8 +179,8 @@ public class ClasspathImpl implements Classpath {
      * @see #setListToBegin()
      * @see #createPathEntry(ClasspathEntry, String)
      */
-    public ClasspathImpl(boolean useBootCP, String classPath) {
-        this.useBootCP = useBootCP;
+    public ClasspathImpl(Release release, String classPath) {
+        this.release = release;
         init(classPath);
     }
 
@@ -336,9 +337,8 @@ public class ClasspathImpl implements Classpath {
                 // just skip this entry
             }
         }
-        if (useBootCP) {
-            final String resourceName = name.replace('.', '/') + ".class";
-            InputStream is = ClassLoader.getSystemClassLoader().getResourceAsStream(resourceName);
+        if (release != null) {
+            InputStream is = release.findClass(name);
             if (is != null) {
                 return is;
             }

--- a/src/main/java/com/sun/tdk/signaturetest/classpath/Release.java
+++ b/src/main/java/com/sun/tdk/signaturetest/classpath/Release.java
@@ -26,6 +26,9 @@ public final class Release {
      * @return found version or null
      */
     public static Release find(int version) {
+        if (version > 15) {
+            return null;
+        }
         char ch = (char) (version < 10 ? '0' + version : 'A' + (version - 10));
         return RELEASES.get(ch);
     }
@@ -36,7 +39,7 @@ public final class Release {
             return ClassLoader.getSystemClassLoader().getResourceAsStream(resourceName);
         } else {
             for (String p : prefixes) {
-                final String resourceName = "/META-INF/ct.sym/" + p + "/" + name.replace('.', '/') + ".class";
+                final String resourceName = "/META-INF/sigtest/" + p + "/" + name.replace('.', '/') + ".sig";
                 InputStream is = Release.class.getResourceAsStream(resourceName);
                 if (is != null) {
                     return is;
@@ -51,7 +54,7 @@ public final class Release {
     static {
         List<String> lines = new ArrayList<>();
         try {
-            try (BufferedReader r = new BufferedReader(new InputStreamReader(Release.class.getResourceAsStream("/META-INF/ct.sym.ls")))) {
+            try (BufferedReader r = new BufferedReader(new InputStreamReader(Release.class.getResourceAsStream("/META-INF/sigtest.ls")))) {
                 for (;;) {
                     String l = r.readLine();
                     if (l == null) {

--- a/src/main/java/com/sun/tdk/signaturetest/classpath/Release.java
+++ b/src/main/java/com/sun/tdk/signaturetest/classpath/Release.java
@@ -1,0 +1,91 @@
+package com.sun.tdk.signaturetest.classpath;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class Release {
+    public static final Release BOOT_CLASS_PATH = new Release('0', null);
+
+    private final char version;
+    private final String[] prefixes;
+
+    private Release(char version, String... prefixes) {
+        this.version = version;
+        this.prefixes = prefixes;
+    }
+
+    /**
+     * Finds version of the JDK API.
+     * @param version 6, 7, 8, 9, ..., 11, ... 15
+     * @return found version or null
+     */
+    public static Release find(int version) {
+        char ch = (char) (version < 10 ? '0' + version : 'A' + (version - 10));
+        return RELEASES.get(ch);
+    }
+
+    InputStream findClass(String name) {
+        if (prefixes == null) {
+            final String resourceName = name.replace('.', '/') + ".class";
+            return ClassLoader.getSystemClassLoader().getResourceAsStream(resourceName);
+        } else {
+            for (String p : prefixes) {
+                final String resourceName = "/META-INF/ct.sym/" + p + "/" + name.replace('.', '/') + ".class";
+                InputStream is = Release.class.getResourceAsStream(resourceName);
+                if (is != null) {
+                    return is;
+                }
+            }
+            return null;
+        }
+
+    }
+
+    private static final Map<Character, Release> RELEASES;
+    static {
+        List<String> lines = new ArrayList<>();
+        try {
+            try (BufferedReader r = new BufferedReader(new InputStreamReader(Release.class.getResourceAsStream("/META-INF/ct.sym.ls")))) {
+                for (;;) {
+                    String l = r.readLine();
+                    if (l == null) {
+                        break;
+                    }
+                    lines.add(l);
+                }
+            }
+        } catch (IOException ex) {
+            throw new InternalError(ex);
+        }
+
+        Map<Character,List<String>> prefixes = new HashMap<>();
+        for (String l : lines) {
+            String[] versionsDir = l.split("/");
+            String versions = versionsDir[0];
+            for (int i = 0; i < versions.length(); i++) {
+                Character ch = versions.charAt(i);
+                List<String> arr = prefixes.get(ch);
+                if (arr == null) {
+                    arr = new ArrayList<>();
+                    prefixes.put(ch, arr);
+                }
+                arr.add(l);
+            }
+        }
+
+        Map<Character,Release> releases = new HashMap<>();
+        for (Map.Entry<Character, List<String>> entry : prefixes.entrySet()) {
+            Character key = entry.getKey();
+            List<String> value = entry.getValue();
+            releases.put(key, new Release(key, value.toArray(new String[0])));
+        }
+
+        RELEASES = releases;
+    }
+}

--- a/src/main/java/com/sun/tdk/signaturetest/core/ClassCorrector.java
+++ b/src/main/java/com/sun/tdk/signaturetest/core/ClassCorrector.java
@@ -733,9 +733,17 @@ public class ClassCorrector implements Transformer {
         for (int i = 0; i < len; ++i) {
             String annoName = annotations[i].getName();
 
-            boolean documented = classHierarchy.isDocumentedAnnotation(annoName);
+            boolean documented;
+            boolean invisible;
+            try {
+                documented = classHierarchy.isDocumentedAnnotation(annoName);
+                invisible = isInvisibleClass(annoName);
+            } catch (ClassNotFoundException ex) {
+                documented = false;
+                invisible = true;
+            }
 
-            if (isInvisibleClass(annoName)) {
+            if (invisible) {
                 if (documented && logger.isLoggable(Level.WARNING))
                     logger.warning(i18n.getString("ClassCorrector.error.invisible_documented_annotation", annoName));
                 annotations[i] = null;

--- a/src/main/java/com/sun/tdk/signaturetest/model/AnnotationItem.java
+++ b/src/main/java/com/sun/tdk/signaturetest/model/AnnotationItem.java
@@ -150,6 +150,19 @@ public class AnnotationItem implements Comparable {
         members.remove(m);
     }
 
+    public static boolean isInternal(String annoName) {
+        if (annoName.startsWith("sun.")) {
+            return true;
+        }
+        if (annoName.startsWith("jdk.")) {
+            return true;
+        }
+        if (annoName.contains(".internal.")) {
+            return true;
+        }
+        return false;
+    }
+
     public static class Member implements Comparable {
         public String type;
         public String name;

--- a/src/main/java/com/sun/tdk/signaturetest/util/I18NResourceBundle.java
+++ b/src/main/java/com/sun/tdk/signaturetest/util/I18NResourceBundle.java
@@ -85,7 +85,7 @@ public class I18NResourceBundle extends ResourceBundle
      * {@link java.text.MessageFormat#format}
      * @return the formatted string
      */
-    public String getString(String key, Object[] args) {
+    public String getString(String key, Object... args) {
         try {
             return MessageFormat.format(getString(key), args);
         }

--- a/src/main/java/org/netbeans/apitest/ListCtSym.java
+++ b/src/main/java/org/netbeans/apitest/ListCtSym.java
@@ -57,4 +57,21 @@ final class ListCtSym {
             }
         }
     }
+
+    static Integer parseReleaseInteger(String release) {
+        if (release == null) {
+            return null;
+        }
+        String r;
+        if (release.startsWith("1.")) {
+            r = release.substring(2);
+        } else {
+            r = release;
+        }
+        try {
+            return Integer.parseInt(r);
+        } catch (NumberFormatException ex) {
+            return null;
+        }
+    }
 }

--- a/src/main/java/org/netbeans/apitest/ListCtSym.java
+++ b/src/main/java/org/netbeans/apitest/ListCtSym.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2007 Sun Microsystems, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Sun designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Sun in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+ * CA 95054 USA or visit www.sun.com if you need additional information or
+ * have any questions.
+ */
+package org.netbeans.apitest;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+
+final class ListCtSym {
+    public static void main(String... args) throws Exception {
+        File lsR = new File(args[0]);
+        File dir = new File(args[1]);
+        int depth = Integer.parseInt(args[2]);
+
+        Writer w = new FileWriter(lsR);
+        dumpDir(w, dir, null, depth);
+        w.close();
+    }
+
+    private static void dumpDir(Writer w, File dir, String prefix, int depth) throws IOException {
+        File[] children = dir.listFiles();
+        if (depth <= 0 || children == null) {
+            return;
+        }
+        int minusOneDepth = depth - 1;
+        for (File ch : children) {
+            String newPrefix = prefix == null ? ch.getName() : prefix + "/" + ch.getName();
+            if (minusOneDepth == 0) {
+                w.append(newPrefix).append("\n");
+            } else {
+                if (ch.isDirectory()) {
+                    dumpDir(w, ch, newPrefix, minusOneDepth);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/netbeans/apitest/Sigtest.java
+++ b/src/main/java/org/netbeans/apitest/Sigtest.java
@@ -198,6 +198,12 @@ public final class Sigtest extends Task {
         }
     }
 
+    /** One of <code>generate</code>,
+        <code>check</code>,
+        <code>strictcheck</code>,
+        <code>versioncheck</code>,
+        <code>binarycheck</code>.
+        */
     public static final class ActionType extends EnumeratedAttribute {
         public String[] getValues() {
             return SigtestHandler.ACTIONS;

--- a/src/main/java/org/netbeans/apitest/Sigtest.java
+++ b/src/main/java/org/netbeans/apitest/Sigtest.java
@@ -46,6 +46,7 @@ public final class Sigtest extends Task {
     Boolean failOnError;
     File report;
     String failureProperty;
+    String release;
 
     public void setFileName(File f) {
         fileName = f;
@@ -92,6 +93,10 @@ public final class Sigtest extends Task {
 
     public void setReport(File report) {
         this.report = report;
+    }
+
+    public void setRelease(String release) {
+        this.release = release;
     }
 
     @Override
@@ -162,6 +167,11 @@ public final class Sigtest extends Task {
             @Override
             protected void logError(String msg) {
                 getProject().log(msg, Project.MSG_ERR);
+            }
+
+            @Override
+            protected Integer getRelease() {
+                return ListCtSym.parseReleaseInteger(release);
             }
         };
         int returnCode;

--- a/src/main/java/org/netbeans/apitest/SigtestCheck.java
+++ b/src/main/java/org/netbeans/apitest/SigtestCheck.java
@@ -44,7 +44,27 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
-/**
+/** Mojo to check {@code .class} files against an existing {@code .sigtest}
+ * file.
+ * <pre>
+&lt;plugin&gt;
+  &lt;groupId&gt;org.netbeans.tools&lt;/groupId&gt;
+  &lt;artifactId&gt;sigtest-maven-plugin&lt;/artifactId&gt;
+  &lt;version&gt;1.3&lt;/version&gt;
+  &lt;executions&gt;
+    &lt;execution&gt;
+      &lt;goals&gt;
+        &lt;goal&gt;check&lt;/goal&gt;
+      &lt;/goals&gt;
+    &lt;/execution&gt;
+  &lt;/executions&gt;
+  &lt;configuration&gt;
+    &lt;packages&gt;org.yourcompany.app.api,org.yourcompany.help.api&lt;/packages&gt;
+    &lt;releaseVersion&gt;1.3&lt;/releaseVersion&gt;
+    &lt;release&gt;8&lt;/release&gt; &lt;!-- specify version of JDK API to use 6,7,8,...15 --&gt;
+  &lt;/configuration&gt;
+&lt;/plugin&gt;
+ * </pre>
  *
  * @author Jaroslav Tulach
  */

--- a/src/main/java/org/netbeans/apitest/SigtestCheck.java
+++ b/src/main/java/org/netbeans/apitest/SigtestCheck.java
@@ -65,6 +65,8 @@ public final class SigtestCheck extends AbstractMojo {
     private File classes;
     @Parameter()
     private File sigfile;
+    @Parameter(property = "maven.compiler.release")
+    private String release;
     @Parameter(property = "sigtest.releaseVersion")
     private String releaseVersion;
     @Parameter(defaultValue = "check", property = "sigtest.check")
@@ -156,6 +158,11 @@ public final class SigtestCheck extends AbstractMojo {
             @Override
             protected void logError(String message) {
                 getLog().error(message);
+            }
+
+            @Override
+            protected Integer getRelease() {
+                return ListCtSym.parseReleaseInteger(release);
             }
         };
         try {

--- a/src/main/java/org/netbeans/apitest/SigtestCompare.java
+++ b/src/main/java/org/netbeans/apitest/SigtestCompare.java
@@ -63,6 +63,8 @@ public final class SigtestCompare extends AbstractMojo {
     @Parameter(defaultValue = "")
     private String packages;
 
+    @Parameter(property = "maven.compiler.release")
+    private String release;
     @Parameter(property = "sigtest.releaseVersion")
     private String releaseVersion;
     @Parameter(defaultValue = "check", property = "sigtest.check")
@@ -91,7 +93,7 @@ public final class SigtestCompare extends AbstractMojo {
             throw new MojoExecutionException("Cannot resolve " + artifact, ex);
         }
 
-        SigtestGenerate generate = new SigtestGenerate(prj, artifact.getFile(), sigfile, packages, releaseVersion);
+        SigtestGenerate generate = new SigtestGenerate(prj, artifact.getFile(), sigfile, packages, releaseVersion, release);
         generate.execute();
 
         SigtestCheck check = new SigtestCheck(prj, classes, sigfile, action, packages, report, failOnError);

--- a/src/main/java/org/netbeans/apitest/SigtestCompare.java
+++ b/src/main/java/org/netbeans/apitest/SigtestCompare.java
@@ -40,7 +40,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
-/**
+/** Mojo to compare {@code .class} files with an existing {@code .sigtest}
+ * file.
  *
  * @author Jaroslav Tulach
  */

--- a/src/main/java/org/netbeans/apitest/SigtestGenerate.java
+++ b/src/main/java/org/netbeans/apitest/SigtestGenerate.java
@@ -58,6 +58,8 @@ public final class SigtestGenerate extends AbstractMojo {
     private File sigfile;
     @Parameter(defaultValue = "")
     private String packages;
+    @Parameter(property = "maven.compiler.release")
+    private String release;
     /**
      * attach the generated file with extension .sigfile to the main artifact for deployment
      */
@@ -68,12 +70,13 @@ public final class SigtestGenerate extends AbstractMojo {
     public SigtestGenerate() {
     }
 
-    SigtestGenerate(MavenProject prj, File classes, File sigfile, String packages, String version) {
+    SigtestGenerate(MavenProject prj, File classes, File sigfile, String packages, String version, String release) {
         this.prj = prj;
         this.classes = classes;
         this.sigfile = sigfile;
         this.packages = packages;
         this.version = version;
+        this.release = release;
     }
 
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -136,6 +139,11 @@ public final class SigtestGenerate extends AbstractMojo {
             @Override
             protected void logError(String message) {
                 getLog().error(message);
+            }
+
+            @Override
+            protected Integer getRelease() {
+                return ListCtSym.parseReleaseInteger(release);
             }
         };
         try {

--- a/src/main/java/org/netbeans/apitest/SigtestGenerate.java
+++ b/src/main/java/org/netbeans/apitest/SigtestGenerate.java
@@ -37,7 +37,25 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 
-/**
+/** Mojo to generate a {@code .sigtest} file.
+ * <pre>
+&lt;plugin&gt;
+  &lt;groupId&gt;org.netbeans.tools&lt;/groupId&gt;
+  &lt;artifactId&gt;sigtest-maven-plugin&lt;/artifactId&gt;
+  &lt;version&gt;1.4&lt;/version&gt;
+  &lt;executions&gt;
+    &lt;execution&gt;
+      &lt;goals&gt;
+        &lt;goal&gt;generate&lt;/goal&gt;
+      &lt;/goals&gt;
+    &lt;/execution&gt;
+  &lt;/executions&gt;
+  &lt;configuration&gt;
+    &lt;release&gt;8&lt;/release&gt; &lt;!-- specify version of JDK API to use 6,7,8,...15 --&gt;
+    &lt;packages&gt;org.yourcompany.app.api,org.yourcompany.help.api&lt;/packages&gt;
+  &lt;/configuration&gt;
+&lt;/plugin&gt;
+ * </pre>
  *
  * @author Jaroslav Tulach
  */

--- a/src/main/java/org/netbeans/apitest/SigtestHandler.java
+++ b/src/main/java/org/netbeans/apitest/SigtestHandler.java
@@ -124,7 +124,11 @@ abstract class SigtestHandler {
                 pref = File.pathSeparator;
             }
             if (addBootCP) {
+                Integer release = getRelease();
                 arg.add("-BootCP");
+                if (release != null) {
+                    arg.add("" + release);
+                }
             }
             arg.add("-Classpath");
             arg.add(sb.toString());
@@ -245,6 +249,7 @@ abstract class SigtestHandler {
         }
     }
 
+    protected abstract Integer getRelease();
     protected abstract String getPackages();
     protected abstract File getFileName();
     protected abstract String getAction();

--- a/src/main/resources/com/sun/tdk/signaturetest/i18n.properties
+++ b/src/main/resources/com/sun/tdk/signaturetest/i18n.properties
@@ -116,6 +116,7 @@ SignatureTest.usage.error_all={0}         Specifies to make the test more strict
 SetupAndTest.helpusage.version={0}          Print version information
 
 SigTest.error.arg.invalid=Invalid value for option: {0}
+SigTest.error.arg.invalid2=Invalid value ({1}) for option: {0}
 
 #SigTest.error.mgr.linkerr=LinkageError
 #SigTest.error.mgr.linkerr.acc=can''t track accessibility : {0} thrown

--- a/src/test/java/com/sun/tdk/signaturetest/classpath/ReleaseTest.java
+++ b/src/test/java/com/sun/tdk/signaturetest/classpath/ReleaseTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2007 Sun Microsystems, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Sun designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Sun in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+ * CA 95054 USA or visit www.sun.com if you need additional information or
+ * have any questions.
+ */
+package com.sun.tdk.signaturetest.classpath;
+
+import com.sun.tdk.signaturetest.loaders.BinaryClassDescrLoader;
+import com.sun.tdk.signaturetest.model.ClassDescription;
+import com.sun.tdk.signaturetest.model.MethodDescr;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ReleaseTest {
+
+    public ReleaseTest() {
+    }
+
+    @Test
+    public void testFindJDK8() throws ClassNotFoundException {
+        Release jdk8 = Release.find(8);
+        assertNotNull(jdk8.findClass("java.lang.Object"));
+        assertNull(jdk8.findClass("java.lang.Module"));
+
+        BinaryClassDescrLoader loader = new BinaryClassDescrLoader(new ClasspathImpl(jdk8, null), 4096);
+        ClassDescription deprecatedClass = loader.load("java.lang.Deprecated");
+        assertMethods(deprecatedClass);
+    }
+
+    @Test
+    public void testFindJDK9() throws ClassNotFoundException {
+        Release jdk9 = Release.find(9);
+        assertNotNull(jdk9.findClass("java.lang.Object"));
+        assertNotNull(jdk9.findClass("java.lang.Module"));
+        assertNull(jdk9.findClass("java.lang.Record"));
+
+        BinaryClassDescrLoader loader = new BinaryClassDescrLoader(new ClasspathImpl(jdk9, null), 4096);
+        ClassDescription deprecatedClass = loader.load("java.lang.Deprecated");
+        assertMethods(deprecatedClass, "forRemoval", "since");
+    }
+
+    @Test
+    public void testFindJDK13() throws ClassNotFoundException {
+        Release jdk13 = Release.find(13);
+        assertNotNull(jdk13.findClass("java.lang.Object"));
+        assertNotNull(jdk13.findClass("java.lang.Module"));
+        assertNull(jdk13.findClass("java.lang.Record"));
+
+        BinaryClassDescrLoader loader = new BinaryClassDescrLoader(new ClasspathImpl(jdk13, null), 4096);
+        ClassDescription deprecatedClass = loader.load("java.lang.Deprecated");
+        assertMethods(deprecatedClass, "forRemoval", "since");
+    }
+
+    @Test
+    public void testFindJDK14() {
+        Release jdk14 = Release.find(14);
+        assertNotNull(jdk14.findClass("java.lang.Object"));
+        assertNotNull(jdk14.findClass("java.lang.Module"));
+        assertNotNull(jdk14.findClass("java.lang.Record"));
+    }
+
+    @Test
+    public void testFindJDK15() throws ClassNotFoundException {
+        Release jdk15 = Release.find(15);
+        assertNotNull(jdk15.findClass("java.lang.Object"));
+        assertNotNull(jdk15.findClass("java.lang.Module"));
+        assertNotNull(jdk15.findClass("java.lang.Record"));
+        BinaryClassDescrLoader loader = new BinaryClassDescrLoader(new ClasspathImpl(jdk15, null), 4096);
+        ClassDescription deprecatedClass = loader.load("java.lang.Deprecated");
+        assertMethods(deprecatedClass, "forRemoval", "since");
+    }
+
+    private void assertMethods(ClassDescription deprecatedClass, String... names) {
+        MethodDescr[] arr = deprecatedClass.getDeclaredMethods();
+        assertEquals("Same number of methods: " + Arrays.toString(arr), names.length, arr.length);
+
+        Set<String> all = new HashSet<>(Arrays.asList(names));
+        for (int i = 0; i < arr.length; i++) {
+            MethodDescr m = arr[i];
+            all.remove(m.getName());
+        }
+
+        assertEquals("Not found methods " + all, 0, all.size());
+    }
+
+
+}

--- a/src/test/java/org/netbeans/apitest/APITest.java
+++ b/src/test/java/org/netbeans/apitest/APITest.java
@@ -941,8 +941,17 @@ public class APITest extends NbTestCase {
         args.addAll(Arrays.asList(additionalArgs));
         args.add("-Ddir1=" + d1);
         args.add("-Ddir2=" + d2);
-        args.add("-Dcheck.release=8");
+        args.add("-Dcheck.release=" + checkRelease());
+        args.add("-Dgenerate.release=" + generateRelease());
         ExecuteUtils.execute(build, args.toArray(new String[0]));
+    }
+
+    protected String checkRelease() {
+        return "invalid-ignore";
+    }
+
+    protected String generateRelease() {
+        return checkRelease();
     }
 
     protected String buildScript() {

--- a/src/test/java/org/netbeans/apitest/APITest.java
+++ b/src/test/java/org/netbeans/apitest/APITest.java
@@ -934,14 +934,19 @@ public class APITest extends NbTestCase {
         File d1 = new File(getWorkDir(), "dir" + slotFirst);
         File d2 = new File(getWorkDir(), "dir" + slotSecond);
 
-        File build = new File(getWorkDir(), "build.xml");
-        extractResource("build.xml", build);
+        File build = new File(getWorkDir(), buildScript());
+        extractResource(buildScript(), build);
 
         List<String> args = new ArrayList<String>();
         args.addAll(Arrays.asList(additionalArgs));
         args.add("-Ddir1=" + d1);
         args.add("-Ddir2=" + d2);
+        args.add("-Dcheck.release=8");
         ExecuteUtils.execute(build, args.toArray(new String[0]));
+    }
+
+    protected String buildScript() {
+        return "build.xml";
     }
 
     static final void copy(String txt, File f) throws Exception {

--- a/src/test/java/org/netbeans/apitest/APIWithReleaseTest.java
+++ b/src/test/java/org/netbeans/apitest/APIWithReleaseTest.java
@@ -50,4 +50,39 @@ public class APIWithReleaseTest extends APITest {
         return "build-with-release.xml";
     }
 
+    @Override
+    protected String generateRelease() {
+        return "14";
+    }
+
+    @Override
+    protected String checkRelease() {
+        return "15";
+    }
+
+    public void testDetectChangeInCharSequence() throws Exception {
+        String c1 =
+            "package ahoj;" +
+            "public interface I extends CharSequence {" +
+            "  public void get();" +
+            "}";
+        createFile(1, "I.java", c1);
+
+
+        String c2 =
+            "package ahoj;" +
+            "public interface I extends CharSequence {" +
+            "  public void get();" +
+            "}";
+        createFile(2, "I.java", c2);
+
+        try {
+            compareAPIs(1, 2, "-Dcheck.package=ahoj.*", "-Dcheck.type=strictcheck");
+            fail("CharSequence.isEmpty() was added in JDK15 and that should be detected");
+        } catch (ExecuteUtils.ExecutionError ex) {
+            String out = ex.getStdErr().replace('\n', ' ');
+            assertTrue(out, out.matches(".*Added Methods.*ahoj.I.*method public boolean java.lang.CharSequence.isEmpty().*"));
+        }
+    }
+
 }

--- a/src/test/java/org/netbeans/apitest/APIWithReleaseTest.java
+++ b/src/test/java/org/netbeans/apitest/APIWithReleaseTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2007 Sun Microsystems, Inc.  All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Sun designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Sun in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Sun Microsystems, Inc., 4150 Network Circle, Santa Clara,
+ * CA 95054 USA or visit www.sun.com if you need additional information or
+ * have any questions.
+ */
+package org.netbeans.apitest;
+
+import junit.framework.Test;
+import org.netbeans.junit.NbTestSuite;
+
+/**
+ *
+ * @author Jaroslav Tulach
+ */
+public class APIWithReleaseTest extends APITest {
+    public APIWithReleaseTest(String s) {
+        super(s);
+    }
+
+    public static Test suite() {
+        Test t = null;
+//        t = new APIWithReleaseTest("testStrictNestedInterfaces");
+        if (t == null) {
+            t = new NbTestSuite(APIWithReleaseTest.class);
+        }
+        return t;
+    }
+
+    @Override
+    protected String buildScript() {
+        return "build-with-release.xml";
+    }
+
+}

--- a/src/test/java/org/netbeans/apitest/ExecuteUtils.java
+++ b/src/test/java/org/netbeans/apitest/ExecuteUtils.java
@@ -105,7 +105,7 @@ final class ExecuteUtils {
         }
     }
 
-    static class ExecutionError extends AssertionFailedError {
+    final static class ExecutionError extends AssertionFailedError {
         public final int exitCode;
 
         public ExecutionError (String msg, int e) {
@@ -113,7 +113,11 @@ final class ExecuteUtils {
             this.exitCode = e;
         }
 
-        public static void assertExitCode (String msg, int e) {
+        public String getStdErr() {
+            return ExecuteUtils.getStdErr();
+        }
+
+        static void assertExitCode (String msg, int e) {
             if (e != 0) {
                 throw new ExecutionError (
                     msg + " was: " + e + "\nOutput: " + out.toString () +

--- a/src/test/java/org/netbeans/apitest/ExecuteUtils.java
+++ b/src/test/java/org/netbeans/apitest/ExecuteUtils.java
@@ -245,12 +245,10 @@ final class ExecuteUtils {
         public void checkAccept (String host, int port) {
         }
 
-        @Override
         @SuppressWarnings("deprecation")
         public void checkMemberAccess (Class clazz, int which) {
         }
 
-        @Override
         @SuppressWarnings("deprecation")
         public void checkSystemClipboardAccess () {
         }
@@ -263,7 +261,6 @@ final class ExecuteUtils {
         public void checkCreateClassLoader () {
         }
 
-        @Override
         @SuppressWarnings("deprecation")
         public void checkAwtEventQueueAccess () {
         }

--- a/src/test/resources/org/netbeans/apitest/build-with-release.xml
+++ b/src/test/resources/org/netbeans/apitest/build-with-release.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="testing build script" default="all" basedir=".">
+    <target name="all">
+        <antcall target="-compile-dir">
+            <param name="dir" value="${dir1}"/>
+        </antcall>
+        <antcall target="-compile-dir">
+            <param name="dir" value="${dir2}"/>
+        </antcall>
+
+        <taskdef name="sigtest" classname="org.netbeans.apitest.Sigtest"/>
+        <property name="check.package" value="x.*"/>
+
+        <sigtest action="generate" release="${check.release}" classpath="${dir1}/api.jar" packages="${check.package}" filename="${dir1}/api.out"/>
+
+        <property name="check.type" value="check"/>
+        <sigtest action="${check.type}" release="${check.release}" classpath="${dir2}/api.jar" packages="${check.package}" filename="${dir1}/api.out"/>
+    </target>
+
+    <target name="generate">
+        <antcall target="-compile-dir">
+            <param name="dir" value="${dir1}"/>
+        </antcall>
+
+        <taskdef name="sigtest" classname="org.netbeans.apitest.Sigtest"/>
+        <property name="check.package" value="x.*"/>
+        <property name="api.out" value="${dir1}/api.out"/>
+
+        <sigtest action="generate" release="${check.release}"
+            classpath="${dir1}/api.jar" packages="${check.package}" filename="${api.out}"
+            failonerror="${fail.on.error}" report="${check.report}"
+        />
+    </target>
+
+    <target name="compare">
+        <antcall target="-compile-dir">
+            <param name="dir" value="${dir1}"/>
+        </antcall>
+
+        <taskdef name="sigtest" classname="org.netbeans.apitest.Sigtest"/>
+        <property name="check.package" value="org.openide.nodes.*"/>
+
+        <property name="check.type" value="check"/>
+        <sigtest action="${check.type}" release="${check.release}" classpath="${dir1}/api.jar" packages="${check.package}" filename="${sig}"/>
+    </target>
+
+    <target name="all-property">
+        <antcall target="-compile-dir">
+            <param name="dir" value="${dir1}"/>
+        </antcall>
+        <antcall target="-compile-dir">
+            <param name="dir" value="${dir2}"/>
+        </antcall>
+
+        <taskdef name="sigtest" classname="org.netbeans.apitest.Sigtest"/>
+        <property name="check.package" value="x.*"/>
+
+        <sigtest action="generate" release="${check.release}" classpath="${dir1}/api.jar" packages="${check.package}" filename="${dir1}/api.out"/>
+
+        <property name="check.type" value="check"/>
+        <sigtest action="${check.type}" release="${check.release}" classpath="${dir2}/api.jar" packages="${check.package}" filename="${dir1}/api.out"
+            failureproperty="f"
+        />
+        <fail message="${check.type} failed" if="f"/>
+    </target>
+
+    <target name="with-version">
+        <antcall target="-compile-dir">
+            <param name="dir" value="${dir1}"/>
+        </antcall>
+        <antcall target="-compile-dir">
+            <param name="dir" value="${dir2}"/>
+        </antcall>
+
+        <taskdef name="sigtest" classname="org.netbeans.apitest.Sigtest"/>
+        <property name="check.package" value="x.*"/>
+
+        <sigtest action="generate" release="${check.release}" classpath="${dir1}/api.jar" version="${v1}" packages="${check.package}" filename="${dir1}/api.out" />
+
+        <property name="check.type" value="check"/>
+        <sigtest action="${check.type}" release="${check.release}" classpath="${dir2}/api.jar" version="${v2}" packages="${check.package}" filename="${dir1}/api.out"/>
+    </target>
+
+    <target name="with-version-junit">
+        <antcall target="-compile-dir">
+            <param name="dir" value="${dir1}"/>
+        </antcall>
+        <antcall target="-compile-dir">
+            <param name="dir" value="${dir2}"/>
+        </antcall>
+
+        <taskdef name="sigtest" classname="org.netbeans.apitest.Sigtest"/>
+        <property name="check.package" value="x.*"/>
+
+        <sigtest action="generate" release="${check.release}" classpath="${dir1}/api.jar" version="${v1}" packages="${check.package}" filename="${dir1}/api.out" />
+
+        <property name="check.type" value="check"/>
+        <sigtest action="${check.type}" release="${check.release}" classpath="${dir2}/api.jar" version="${v2}" packages="${check.package}" filename="${dir1}/api.out"
+            report="${check.report}"
+        />
+        <junitreport todir="${dir2}">
+            <fileset dir="${check.report}/..">
+                <include name="*.xml"/>
+            </fileset>
+        </junitreport>
+    </target>
+
+    <target name="-compile-dir">
+        <delete dir="${dir}/classes"/>
+        <mkdir dir="${dir}/classes"/>
+        <javac srcdir="${dir}" fork="false" destdir="${dir}/classes"/>
+        <jar basedir="${dir}/classes" includes="**/*.class" jarfile="${dir}/api.jar"/>
+    </target>
+</project>

--- a/src/test/resources/org/netbeans/apitest/build-with-release.xml
+++ b/src/test/resources/org/netbeans/apitest/build-with-release.xml
@@ -11,7 +11,7 @@
         <taskdef name="sigtest" classname="org.netbeans.apitest.Sigtest"/>
         <property name="check.package" value="x.*"/>
 
-        <sigtest action="generate" release="${check.release}" classpath="${dir1}/api.jar" packages="${check.package}" filename="${dir1}/api.out"/>
+        <sigtest action="generate" release="${generate.release}" classpath="${dir1}/api.jar" packages="${check.package}" filename="${dir1}/api.out"/>
 
         <property name="check.type" value="check"/>
         <sigtest action="${check.type}" release="${check.release}" classpath="${dir2}/api.jar" packages="${check.package}" filename="${dir1}/api.out"/>
@@ -26,7 +26,7 @@
         <property name="check.package" value="x.*"/>
         <property name="api.out" value="${dir1}/api.out"/>
 
-        <sigtest action="generate" release="${check.release}"
+        <sigtest action="generate" release="${generate.release}"
             classpath="${dir1}/api.jar" packages="${check.package}" filename="${api.out}"
             failonerror="${fail.on.error}" report="${check.report}"
         />
@@ -55,7 +55,7 @@
         <taskdef name="sigtest" classname="org.netbeans.apitest.Sigtest"/>
         <property name="check.package" value="x.*"/>
 
-        <sigtest action="generate" release="${check.release}" classpath="${dir1}/api.jar" packages="${check.package}" filename="${dir1}/api.out"/>
+        <sigtest action="generate" release="${generate.release}" classpath="${dir1}/api.jar" packages="${check.package}" filename="${dir1}/api.out"/>
 
         <property name="check.type" value="check"/>
         <sigtest action="${check.type}" release="${check.release}" classpath="${dir2}/api.jar" packages="${check.package}" filename="${dir1}/api.out"
@@ -75,7 +75,7 @@
         <taskdef name="sigtest" classname="org.netbeans.apitest.Sigtest"/>
         <property name="check.package" value="x.*"/>
 
-        <sigtest action="generate" release="${check.release}" classpath="${dir1}/api.jar" version="${v1}" packages="${check.package}" filename="${dir1}/api.out" />
+        <sigtest action="generate" release="${generate.release}" classpath="${dir1}/api.jar" version="${v1}" packages="${check.package}" filename="${dir1}/api.out" />
 
         <property name="check.type" value="check"/>
         <sigtest action="${check.type}" release="${check.release}" classpath="${dir2}/api.jar" version="${v2}" packages="${check.package}" filename="${dir1}/api.out"/>
@@ -92,7 +92,7 @@
         <taskdef name="sigtest" classname="org.netbeans.apitest.Sigtest"/>
         <property name="check.package" value="x.*"/>
 
-        <sigtest action="generate" release="${check.release}" classpath="${dir1}/api.jar" version="${v1}" packages="${check.package}" filename="${dir1}/api.out" />
+        <sigtest action="generate" release="${generate.release}" classpath="${dir1}/api.jar" version="${v1}" packages="${check.package}" filename="${dir1}/api.out" />
 
         <property name="check.type" value="check"/>
         <sigtest action="${check.type}" release="${check.release}" classpath="${dir2}/api.jar" version="${v2}" packages="${check.package}" filename="${dir1}/api.out"


### PR DESCRIPTION
Many projects observed problems executing SigTest when switching the version of JDK the test is performed on. As soon as the JDK changes, the API of base Java classes changes as well. SigTest may then detect _transitive_ changes even the actual API hasn't changed at all. As #2 PR indicates we need a solution to this problem.

Let's use the `ct.sym` approach (as pioneered by `javac` in JDK9). E.g. specify the _release_ of JDK API to compare against. Then it wouldn't matter which JDK is used for running the check. - the JDK API used in the check would always be fixed to the specified _release_ version.

This PR enhances the `-BootCP` command line argument to understand an optional parameter. Use `-BootCp 8` to select JDK8's API as the base. Use `-BootCP 15` to select JDK 15's API. Use `-BootCp` without parameter to select the API of the underlaying JDK SigTest runs on (the original behavior). The PR reuses existing `-BootCp` functionality and enhances it rather than inventing new option - at the end only one occurence of `-BootCp <with or without number>` makes sense. 

Both Ant and Maven integrations were enhanced to provide new `release` attribute (trying to mimic the name of attribute of Ant `JavacTask` and Maven compiler plugin)  - if specified, it uses the `-BootCp number` parameter when calling into the SigTest.

Documentation has been updated and a test verifying addition of `CharSequence.isEmpty()` in JDK15 is properly detected has been added.