### PR TITLE
Provide new addProjectClasspath parm to exclude project target & deps from goal classpath for fine-grained control

### DIFF
--- a/src/main/java/org/netbeans/apitest/SigtestCheck.java
+++ b/src/main/java/org/netbeans/apitest/SigtestCheck.java
@@ -97,11 +97,18 @@ public final class SigtestCheck extends AbstractMojo {
     private File report;
     @Parameter(defaultValue = "true", property = "sigtest.fail")
     private boolean failOnError;
+    /**
+     * By default (with value set to <true>) the project build directory as well as the project dependencies are added to the sigtest classpath.
+     * If set to <false> then only the path configured in <code>classes</code> will be added to the sigtest classpath for this goal.
+     */
+    @Parameter(defaultValue = "true", property = "sigtest.addProjectClassPath")
+    private boolean addProjectClasspath;
+
 
     public SigtestCheck() {
     }
 
-    SigtestCheck(MavenProject prj, File classes, File sigfile, String action, String packages, File report, boolean failOnError) {
+    SigtestCheck(MavenProject prj, File classes, File sigfile, String action, String packages, File report, boolean failOnError, boolean addProjectClasspath) {
         this.prj = prj;
         this.classes = classes;
         this.sigfile = sigfile;
@@ -109,9 +116,8 @@ public final class SigtestCheck extends AbstractMojo {
         this.packages = packages;
         this.report = report;
         this.failOnError = failOnError;
+        this.addProjectClasspath = addProjectClasspath;
     }
-
-
 
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (packages == null) {
@@ -152,7 +158,7 @@ public final class SigtestCheck extends AbstractMojo {
 
             @Override
             protected String[] getClasspath() {
-                return projectClassPath(prj, classes);
+                return projectClassPath(prj, classes, addProjectClasspath);
             }
 
             @Override
@@ -205,13 +211,15 @@ public final class SigtestCheck extends AbstractMojo {
         }
     }
 
-    static String[] projectClassPath(MavenProject project, File classes) {
+    static String[] projectClassPath(MavenProject project, File classes, boolean addProjectClasspath) {
         Set<String> path = new LinkedHashSet<String>();
         path.add(classes.getAbsolutePath());
-        path.add(project.getBuild().getOutputDirectory());
-        for (Artifact a : project.getArtifacts()) {
-            if (a.getFile() != null && a.getFile().exists()) {
-                path.add(a.getFile().getAbsolutePath());
+        if (addProjectClasspath) {
+            path.add(project.getBuild().getOutputDirectory());
+            for (Artifact a : project.getArtifacts()) {
+                if (a.getFile() != null && a.getFile().exists()) {
+                    path.add(a.getFile().getAbsolutePath());
+                }
             }
         }
         return path.toArray(new String[0]);

--- a/src/main/java/org/netbeans/apitest/SigtestCompare.java
+++ b/src/main/java/org/netbeans/apitest/SigtestCompare.java
@@ -74,6 +74,12 @@ public final class SigtestCompare extends AbstractMojo {
     private File report;
     @Parameter(defaultValue = "true", property = "sigtest.fail")
     private boolean failOnError;
+    /**
+     * By default (with value set to <true>) the project build directory as well as the project dependencies are added to the sigtest classpath.
+     * If set to <false> then only the path configured in <code>classes</code> will be added to the sigtest classpath for this goal.
+     */
+    @Parameter(defaultValue = "true", property = "sigtest.addProjectClassPath")
+    private boolean addProjectClasspath;
 
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (packages == null) {
@@ -94,10 +100,10 @@ public final class SigtestCompare extends AbstractMojo {
             throw new MojoExecutionException("Cannot resolve " + artifact, ex);
         }
 
-        SigtestGenerate generate = new SigtestGenerate(prj, artifact.getFile(), sigfile, packages, releaseVersion, release);
+        SigtestGenerate generate = new SigtestGenerate(prj, artifact.getFile(), sigfile, packages, releaseVersion, release, addProjectClasspath);
         generate.execute();
 
-        SigtestCheck check = new SigtestCheck(prj, classes, sigfile, action, packages, report, failOnError);
+        SigtestCheck check = new SigtestCheck(prj, classes, sigfile, action, packages, report, failOnError, addProjectClasspath);
         check.execute();
     }
 }

--- a/src/main/java/org/netbeans/apitest/SigtestGenerate.java
+++ b/src/main/java/org/netbeans/apitest/SigtestGenerate.java
@@ -83,18 +83,26 @@ public final class SigtestGenerate extends AbstractMojo {
      */
     @Parameter(defaultValue = "true")
     private boolean attach;
+    /**
+     * By default (with value set to <true>) the project build directory as well as the project dependencies are added to the sigtest classpath.
+     * If set to <false> then only the path configured in <code>classes</code> will be added to the sigtest classpath for this goal.
+     */
+    @Parameter(defaultValue = "true", property = "sigtest.addProjectClassPath")
+    private boolean addProjectClasspath;
+
     private String version;
 
     public SigtestGenerate() {
     }
 
-    SigtestGenerate(MavenProject prj, File classes, File sigfile, String packages, String version, String release) {
+    SigtestGenerate(MavenProject prj, File classes, File sigfile, String packages, String version, String release,  boolean addProjectClasspath) {
         this.prj = prj;
         this.classes = classes;
         this.sigfile = sigfile;
         this.packages = packages;
         this.version = version;
         this.release = release;
+        this.addProjectClasspath = addProjectClasspath;
     }
 
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -131,7 +139,7 @@ public final class SigtestGenerate extends AbstractMojo {
 
             @Override
             protected String[] getClasspath() {
-                return SigtestCheck.projectClassPath(prj, classes);
+                return SigtestCheck.projectClassPath(prj, classes, addProjectClasspath);
             }
 
             @Override


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

I think it could be desirable to give more fine-grained control of the classpath and exclude project dependencies and the default target location, and use only the plugin config, e.g.
>           <classes>${project.build.directory}/my-unpack</classes>

Added as

```java
   /**
     * By default (with value set to <true>) the project build directory as well as the project dependencies are added to the sigtest classpath.
     * If set to <false> then only the path configured in <code>classes</code> will be added to the sigtest classpath for this goal.
     */
    @Parameter(defaultValue = "true", property = "sigtest.addProjectClassPath")
    private boolean addProjectClasspath;
```

So you can set as:

```xml
   <configuration>
       <addProjectClasspath>false</addProjectClasspath>
   </configuration
```

or **-Dsigtest.addProjectClassPath=false**


The default of `true` matches the existing behavior.