### PR TITLE
Fix mapping of 'packages' parameter ending in .** to -Package parm (including subpackages)

### DIFF
--- a/src/main/java/org/netbeans/apitest/SigtestHandler.java
+++ b/src/main/java/org/netbeans/apitest/SigtestHandler.java
@@ -102,13 +102,13 @@ abstract class SigtestHandler {
             String p = packagesTokenizer.nextToken().trim();
             String prefix = "-PackageWithoutSubpackages "; // NOI18N
             //Strip the ending ".*"
-            int idx = p.lastIndexOf(".*");
+            int idx = p.lastIndexOf(".**");
             if (idx > 0) {
                 p = p.substring(0, idx);
+                prefix = "-Package "; // NOI18N
             } else {
-                idx = p.lastIndexOf(".**");
+                idx = p.lastIndexOf(".*");
                 if (idx > 0) {
-                    prefix = "-Package "; // NOI18N
                     p = p.substring(0, idx);
                 }
             }


### PR DESCRIPTION

### PROBLEM 

IIUC, the use case where I want to include subpackages in the test, e.g. so that I can make sure no extra packages have been added to the API under test with a given package prefix is supposed to map the plugin config to the `-Package`  parameter in the underlying execution.  

E.g. if I want to make sure that API with pkgs:  **a.b.c**  and **a.b.d** doesn't end up with an extra **a.b.e** package, then I want to use something like `-Package a.b`.

I'm assuming this [doc](https://docs.oracle.com/javacomponents/sigtest-3-1/user-guide/sig_using.htm#Z4000c461058601) still describes this to some extent.

If we look at the code it looks like the plugin config tries to expose this use case using a `.**` suffix convention.  E.g. for the case above it looks like it's expecting me this: `<packages>a.b.**</packages>` for a 'check' goal execution.

However, looking at the code: 
https://github.com/jtulach/netbeans-apitest/blob/35822c3de5132a0b6d4a097038b62e82f540d136/src/main/java/org/netbeans/apitest/SigtestHandler.java#L101-L114

this won't work.  We'll never go down the path setting up `-Package` since if we match `.**` we'll also always match `.*` first.

###  SOLUTION

I reversed the check 

### TESTS

Maybe this would be worth a test.   I noticed though that I have about six test failures before and after my PR.. so I'm not sure I'm in a stable place to add a test.   Do the existing tests exercise the Maven plugin layer (or just the "back-end")?



Signed-off-by: Scott Kurz <skurz@us.ibm.com>