### PR TITLE
fix ArrayIndexOutOfBoundsException from SignatureTest.checkAnnotations(SignatureTest.java:1449

### DIFF
--- a/src/main/java/com/sun/tdk/signaturetest/SignatureTest.java
+++ b/src/main/java/com/sun/tdk/signaturetest/SignatureTest.java
@@ -1447,7 +1447,7 @@ public class SignatureTest extends SigTest {
         while ((bPos < bl) && (tPos < tl)) {
             int comp = 0;
             if (jdkExclude.isJdkClass(baseAnnotList[bPos].getName()) || 
-                    jdkExclude.isJdkClass(testAnnotList[bPos].getName())) {
+                    jdkExclude.isJdkClass(testAnnotList[tPos].getName())) {
                 comp = baseAnnotList[bPos].getName().compareTo(testAnnotList[tPos].getName());
             } else {
                 comp = baseAnnotList[bPos].compareTo(testAnnotList[tPos]);


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

Just noticed the below failure:

> javatest.batch] ^[[0m^[[0m23:59:29,363 INFO  [stdout] (Thread-118)     at jdk.internal.reflect.GeneratedMethodAccessor6.invoke(Unknown Source)
> [javatest.batch] ^[[0m^[[0m23:59:29,363 INFO  [stdout] (Thread-118)     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> [javatest.batch] ^[[0m^[[0m23:59:29,364 INFO  [stdout] (Thread-118)     at java.base/java.lang.reflect.Method.invoke(Method.java:566)
> [javatest.batch] ^[[0m^[[0m23:59:29,364 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear.JavaEESigTest_appclient_vehicle_client.jar//com.sun.ts.tests.signaturetest.SigTestDriver.runSignatureTest(SigTestDriver.java:180)
> [javatest.batch] ^[[0m^[[0m23:59:29,364 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear.JavaEESigTest_appclient_vehicle_client.jar//com.sun.ts.tests.signaturetest.SignatureTestDriver.executeSigTest(SignatureTestDriver.java:194)
> [javatest.batch] ^[[0m^[[0m23:59:29,364 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear.JavaEESigTest_appclient_vehicle_client.jar//com.sun.ts.tests.signaturetest.SigTestEE.signatureTest(SigTestEE.java:277)
> [javatest.batch] ^[[0m^[[0m23:59:29,364 INFO  [stdout] (Thread-118)     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> [javatest.batch] ^[[0m^[[0m23:59:29,364 INFO  [stdout] (Thread-118)     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
> [javatest.batch] ^[[0m^[[0m23:59:29,364 INFO  [stdout] (Thread-118)     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> [javatest.batch] ^[[0m^[[0m23:59:29,364 INFO  [stdout] (Thread-118)     at java.base/java.lang.reflect.Method.invoke(Method.java:566)
> [javatest.batch] ^[[0m^[[0m23:59:29,364 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear.JavaEESigTest_appclient_vehicle_client.jar//com.sun.ts.lib.harness.EETest.run(EETest.java:596)
> [javatest.batch] ^[[0m^[[0m23:59:29,364 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear.JavaEESigTest_appclient_vehicle_client.jar//com.sun.ts.lib.harness.ServiceEETest.run(ServiceEETest.java:115)
> [javatest.batch] ^[[0m^[[0m23:59:29,392 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear.JavaEESigTest_appclient_vehicle_client.jar//com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.run(EmptyVehicleRunner.java:41)
> [javatest.batch] ^[[0m^[[0m23:59:29,392 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear.JavaEESigTest_appclient_vehicle_client.jar//com.sun.ts.lib.harness.ServiceEETest.run(ServiceEETest.java:105)
> [javatest.batch] ^[[0m^[[0m23:59:29,392 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear.JavaEESigTest_appclient_vehicle_client.jar//com.sun.ts.lib.harness.EETest.getPropsReady(EETest.java:486)
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear.JavaEESigTest_appclient_vehicle_client.jar//com.sun.ts.lib.harness.ServiceEETest.run(ServiceEETest.java:209)
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear.JavaEESigTest_appclient_vehicle_client.jar//com.sun.ts.lib.harness.EETest.run(EETest.java:285)
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear.JavaEESigTest_appclient_vehicle_client.jar//com.sun.ts.tests.common.vehicle.VehicleClient.main(VehicleClient.java:37)
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118)     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118)     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118)     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118)     at java.base/java.lang.reflect.Method.invoke(Method.java:566)
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118)     at org.jboss.as.appclient@27.0.0.Alpha2-SNAPSHOT//org.jboss.as.appclient.service.ApplicationClientStartService$1.run(ApplicationClientStartService.java:100)
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118)     at java.base/java.lang.Thread.run(Thread.java:829)
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118) Caused by: java.lang.ArrayIndexOutOfBoundsException: Index 2 out of bounds for length 2
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear//com.sun.tdk.signaturetest.SignatureTest.checkAnnotations(SignatureTest.java:1449)
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear//com.sun.tdk.signaturetest.SignatureTest.checkClassDescription(SignatureTest.java:1265)
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear//com.sun.tdk.signaturetest.SignatureTest.verifyClass(SignatureTest.java:1196)
> [javatest.batch] ^[[0m^[[0m23:59:29,404 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear//com.sun.tdk.signaturetest.SignatureTest.verifyClass(SignatureTest.java:1058)
> [javatest.batch] ^[[0m^[[0m23:59:29,440 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear//com.sun.tdk.signaturetest.SignatureTest.check(SignatureTest.java:821)
> [javatest.batch] ^[[0m^[[0m23:59:29,440 INFO  [stdout] (Thread-118)     at deployment.JavaEESigTest_appclient_vehicle.ear//com.sun.tdk.signaturetest.SignatureTest.run(SignatureTest.java:293)
> [javatest.batch] ^[[0m^[[0m23:59:29,440 INFO  [stdout] (Thread-118)     ... 24 more


This pull request addresses ^ 