### PR TITLE
Fix ClassFormatError on jdk25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
                 <configuration>
                     <compilerId>frgaal</compilerId>
                     <source>15</source>
-                    <target>1.8</target>
+                    <target>15</target>
                     <compilerArgs>
                         <arg>-Xlint:deprecation</arg>
                     </compilerArgs>
@@ -107,7 +107,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.9.0</version>
                 <configuration>
                     <extractors>
                         <extractor>java-annotations</extractor>

--- a/src/test/java/org/netbeans/apitest/APITest.java
+++ b/src/test/java/org/netbeans/apitest/APITest.java
@@ -63,6 +63,49 @@ public class APITest extends NbTestCase {
         clearWorkDir();
     }
 
+    public void testWeakReference() throws Exception {
+        String c1 = """
+                package ahoj;
+                
+                import java.lang.ref.ReferenceQueue;
+                import java.lang.ref.WeakReference;
+                
+                public final class MyWeakReference<T> extends WeakReference<T> {
+                
+                    public MyWeakReference(T t) {
+                        super(t);
+                    }
+                
+                    public MyWeakReference(T referent, ReferenceQueue<? super T> q) {
+                        super(referent, q);
+                    }
+                }
+                """;
+        createFile(1, "MyWeakReference.java", c1);
+
+
+        String c2 = """
+                package ahoj;
+                
+                import java.lang.ref.ReferenceQueue;
+                import java.lang.ref.WeakReference;
+                
+                public final class MyWeakReference<T> extends WeakReference<T> {
+                
+                    public MyWeakReference(T t) {
+                        super(t);
+                    }
+                
+                    public MyWeakReference(T referent, ReferenceQueue<? super T> q) {
+                        super(referent, q);
+                    }
+                }
+                """;
+        createFile(2, "MyWeakReference.java", c2);
+
+        compareAPIs(1, 2, "-Dcheck.package=ahoj.*");
+    }
+
     public void testAddingObjectMethodToAnInterfaceIsOK() throws Exception {
         String c1 =
             "package ahoj;" +

--- a/src/test/java/org/netbeans/apitest/ExecuteUtils.java
+++ b/src/test/java/org/netbeans/apitest/ExecuteUtils.java
@@ -24,17 +24,21 @@
  */
 package org.netbeans.apitest;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileDescriptor;
-import java.io.PrintStream;
-import java.io.PrintWriter;
+import java.io.*;
 import java.net.InetAddress;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
 import junit.framework.AssertionFailedError;
+import org.apache.tools.ant.taskdefs.optional.junit.JUnitTest;
 import org.junit.Assert;
 
 /**
@@ -44,6 +48,8 @@ import org.junit.Assert;
 final class ExecuteUtils {
     private static ByteArrayOutputStream out;
     private static ByteArrayOutputStream err;
+    private static PrintStream printOut;
+    private static PrintStream printErr;
 
     private ExecuteUtils() {
     }
@@ -56,17 +62,24 @@ final class ExecuteUtils {
     }
 
     final static void execute(File f, String[] args) throws Exception {
+        URL loc = org.apache.tools.ant.Main.class.getProtectionDomain().getCodeSource().getLocation();
+        Path antJar = Paths.get(loc.toURI());
+        loc = org.apache.tools.ant.launch.AntMain.class.getProtectionDomain().getCodeSource().getLocation();
+        Path antLaunchJar = Paths.get(loc.toURI());
+        loc = JUnitTest.class.getProtectionDomain().getCodeSource().getLocation();
+        Path antJunitJar = Paths.get(loc.toURI());
+        loc = Sigtest.class.getProtectionDomain().getCodeSource().getLocation();
+        Path sigTestJar = Paths.get(loc.toURI());
+        Optional<String> javaCommandOpt = ProcessHandle.current().info().command();
+
+
         // we need security manager to prevent System.exit
-        if (! (System.getSecurityManager () instanceof MySecMan)) {
+        if (out == null) {
             out = new java.io.ByteArrayOutputStream ();
             err = new java.io.ByteArrayOutputStream ();
-            System.setOut (new java.io.PrintStream (out));
-            System.setErr (new java.io.PrintStream (err));
-
-            System.setSecurityManager (new MySecMan ());
+            printOut = new java.io.PrintStream (out);
+            printErr = new java.io.PrintStream (err);
         }
-
-        MySecMan sec = (MySecMan)System.getSecurityManager();
 
         // Jesse claims that this is not the right way how the execution
         // of an ant script should be invoked:
@@ -83,25 +96,52 @@ final class ExecuteUtils {
         // needs that...
 
         List<String> arr = new ArrayList<>();
+        arr.add(javaCommandOpt.get());
+        arr.add("-cp");
+        String ps = System.getProperty("path.separator");
+        arr.add(antJar + ps + antLaunchJar + ps + antJunitJar + ps + sigTestJar);
+        arr.add("org.apache.tools.ant.Main");
         arr.add ("-f");
-        arr.add (f.toString ());
+        arr.add (f.toString());
         arr.addAll(Arrays.asList(args));
         arr.add ("-verbose");
         if (System.getProperty("java.version").startsWith("1.8")) {
             arr.add ("-Dbuild.compiler=extjavac");
         }
 
-        out.reset ();
-        err.reset ();
+        out.reset();
+        err.reset();
+        ProcessBuilder pb = new ProcessBuilder(arr);
+        Process p = pb.start();
+        try (BufferedReader rOut = new BufferedReader(
+                new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8)); BufferedReader rErr = new BufferedReader(
+                new InputStreamReader(p.getErrorStream(), StandardCharsets.UTF_8))) {
+            boolean endReached;
+            do {
+                endReached = true;
+                String line;
+                if ((line = rOut.readLine()) != null) {
+                    printOut.println(line);
+                    endReached = false;
+                }
+                if ((line = rErr.readLine()) != null) {
+                    printErr.println(line);
+                    endReached = false;
+                }
+            } while (!endReached);
+        }
 
-        try {
-            sec.setActive(true);
-            org.apache.tools.ant.Main.main (arr.toArray(new String[0]));
-        } catch (MySecExc ex) {
-            Assert.assertNotNull ("The only one to throw security exception is MySecMan and should set exitCode", sec.exitCode);
-            ExecutionError.assertExitCode ("Execution has to finish without problems", sec.exitCode);
-        } finally {
-            sec.setActive(false);
+        if (!p.waitFor(30, TimeUnit.SECONDS)) {
+            p.destroyForcibly();
+            throw new ExecutionError("Process timed out", -1);
+        }
+
+        int exit = p.exitValue();
+        ExecutionError.assertExitCode ("Execution has to finish without problems", exit);
+        if (err.toString().contains("java.lang.ClassFormatError") || out.toString().contains("java.lang.ClassFormatError")) {
+            System.err.println(out.toString());
+            System.err.println(err.toString());
+            throw new AssertionError("Class format error detected");
         }
     }
 


### PR DESCRIPTION
I added a test that reproduces the following exception:

```
[sigtest] java.lang.ClassFormatError: Index out of the constant pool bounds
  [sigtest] 	at com.sun.tdk.signaturetest.loaders.BinaryClassDescrLoader$BinaryClassDescription.getConstant(BinaryClassDescrLoader.java:126)
  [sigtest] 	at com.sun.tdk.signaturetest.loaders.BinaryClassDescrLoader$BinaryClassDescription.getName(BinaryClassDescrLoader.java:173)
  [sigtest] 	at com.sun.tdk.signaturetest.loaders.BinaryClassDescrLoader$AttrsIter.readAnnotation(BinaryClassDescrLoader.java:1103)
  [sigtest] 	at com.sun.tdk.signaturetest.loaders.BinaryClassDescrLoader$AttrsIter.readExtAnnotations(BinaryClassDescrLoader.java:985)
  [sigtest] 	at com.sun.tdk.signaturetest.loaders.BinaryClassDescrLoader$AttrsIter.read(BinaryClassDescrLoader.java:926)
  [sigtest] 	at com.sun.tdk.signaturetest.loaders.BinaryClassDescrLoader.readClass(BinaryClassDescrLoader.java:423)
  [sigtest] 	at com.sun.tdk.signaturetest.loaders.BinaryClassDescrLoader.readClass(BinaryClassDescrLoader.java:366)
  [sigtest] 	at com.sun.tdk.signaturetest.loaders.BinaryClassDescrLoader.load(BinaryClassDescrLoader.java:243)
  [sigtest] 	at com.sun.tdk.signaturetest.core.ClassHierarchyImpl.load(ClassHierarchyImpl.java:180)
  [sigtest] 	at com.sun.tdk.signaturetest.core.ClassHierarchyImpl.load(ClassHierarchyImpl.java:164)
  [sigtest] 	at com.sun.tdk.signaturetest.core.ClassSet.addClass(ClassSet.java:84)
  [sigtest] 	at com.sun.tdk.signaturetest.core.ClassSet.addClass(ClassSet.java:99)
  [sigtest] 	at com.sun.tdk.signaturetest.core.ClassSet.addClass(ClassSet.java:70)
  [sigtest] 	at com.sun.tdk.signaturetest.Setup.create(Setup.java:418)
  [sigtest] 	at com.sun.tdk.signaturetest.Setup.run(Setup.java:164)
  [sigtest] 	at org.netbeans.apitest.SigtestHandler.execute(SigtestHandler.java:150)
  [sigtest] 	at org.netbeans.apitest.Sigtest.execute(Sigtest.java:184)
  [sigtest] 	at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
  [sigtest] 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
  [sigtest] 	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
  [sigtest] 	at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:99)
  [sigtest] 	at org.apache.tools.ant.Task.perform(Task.java:350)
  [sigtest] 	at org.apache.tools.ant.Target.execute(Target.java:449)
  [sigtest] 	at org.apache.tools.ant.Target.performTasks(Target.java:470)
  [sigtest] 	at org.apache.tools.ant.Project.executeSortedTargets(Project.java:1388)
  [sigtest] 	at org.apache.tools.ant.Project.executeTarget(Project.java:1361)
  [sigtest] 	at org.apache.tools.ant.helper.DefaultExecutor.executeTargets(DefaultExecutor.java:41)
  [sigtest] 	at org.apache.tools.ant.Project.executeTargets(Project.java:1251)
  [sigtest] 	at org.apache.tools.ant.Main.runBuild(Main.java:834)
  [sigtest] 	at org.apache.tools.ant.Main.startAnt(Main.java:223)
  [sigtest] 	at org.apache.tools.ant.Main.start(Main.java:190)
  [sigtest] 	at org.apache.tools.ant.Main.main(Main.java:274)
```
Printing of the exception does not seem to stop the generation of the signatures, but it is certainly a manifestation of some problem.